### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/chrisboesch/singpathfire.png?label=ready&title=Ready)](https://waffle.io/chrisboesch/singpathfire)
 [![Build Status](https://travis-ci.org/ChrisBoesch/singpathfire.svg)](https://travis-ci.org/ChrisBoesch/singpathfire)[![Coverage Status](https://coveralls.io/repos/ChrisBoesch/singpathfire/badge.svg)](https://coveralls.io/r/ChrisBoesch/singpathfire)
 
 # Class mentors


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/chrisboesch/singpathfire

This was requested by a real person (user SingaporeClouds) on waffle.io, we're not trying to spam you.