### PR TITLE
Fix event progress updater and test

### DIFF
--- a/src/classmentors/app.js
+++ b/src/classmentors/app.js
@@ -465,6 +465,10 @@
           },
 
           updateProgress: function(event, publicId) {
+            if (!publicId) {
+              return $q.reject('User public id is missing missing.');
+            }
+
             var singPathProfilePromise = clmDataStore.singPath.profile(publicId);
 
             // Get map of service used in that event.

--- a/src/classmentors/app.spec.js
+++ b/src/classmentors/app.spec.js
@@ -667,6 +667,33 @@
               spfFirebase.objFactory.and.returnValue(profileFactory);
             });
 
+            it('should reject if the public id is missing', inject(function($rootScope, $q, clmDataStore) {
+              var err;
+              var event = {
+                $id: 'someEventId',
+                tasks: {
+                  someTaskId: {
+                    serviceId: 'codeSchool'
+                  }
+                }
+              };
+
+              clmDataStore.services.codeCombat.updateProfile = jasmine.createSpy('codeCombat.updateProfile');
+              clmDataStore.services.codeSchool.updateProfile = jasmine.createSpy('codeSchool.updateProfile');
+              profileObj.$loaded.and.returnValue($q.when({$id: 'bob'}));
+              spfFirebase.set.and.returnValue({});
+
+              clmDataStore.events.updateProgress(event).catch(function(_err) {
+                err = _err;
+              });
+
+              $rootScope.$apply();
+              expect(err).toBeDefined();
+              expect(clmDataStore.services.codeCombat.updateProfile.calls.count()).toBe(0);
+              expect(clmDataStore.services.codeSchool.updateProfile.calls.count()).toBe(0);
+              expect(spfFirebase.set.calls.count()).toBe(0);
+            }));
+
             it('should not update progress when user has not joined the required service',
               inject(function($rootScope, $q, clmDataStore) {
                 var event = {
@@ -688,11 +715,8 @@
                 clmDataStore.services.codeSchool.updateProfile = jasmine.createSpy('codeSchool.updateProfile');
                 profileObj.$loaded.and.returnValue($q.when(profile));
                 spfFirebase.set.and.returnValue(expectedReturn);
-                spfAuthData.user.and.returnValue($q.when({
-                  publicId: 'bob'
-                }));
 
-                clmDataStore.events.updateProgress(event).then(function(completedTasks) {
+                clmDataStore.events.updateProgress(event, 'bob').then(function(completedTasks) {
                   actualReturn = completedTasks;
                 });
 
@@ -738,11 +762,8 @@
                 clmDataStore.services.codeSchool.updateProfile = jasmine.createSpy('codeSchool.updateProfile');
                 profileObj.$loaded.and.returnValue($q.when(profile));
                 spfFirebase.set.and.returnValue(expectedReturn);
-                spfAuthData.user.and.returnValue($q.when({
-                  publicId: 'bob'
-                }));
 
-                clmDataStore.events.updateProgress(event).then(function(completedTasks) {
+                clmDataStore.events.updateProgress(event, 'bob').then(function(completedTasks) {
                   actualReturn = completedTasks;
                 });
 
@@ -794,11 +815,8 @@
                 clmDataStore.services.codeSchool.updateProfile = jasmine.createSpy('codeSchool.updateProfile');
                 profileObj.$loaded.and.returnValue($q.when(profile));
                 spfFirebase.set.and.returnValue(expectedReturn);
-                spfAuthData.user.and.returnValue($q.when({
-                  publicId: 'bob'
-                }));
 
-                clmDataStore.events.updateProgress(event).then(function(completedTasks) {
+                clmDataStore.events.updateProgress(event, 'bob').then(function(completedTasks) {
                   actualReturn = completedTasks;
                 });
 
@@ -844,11 +862,8 @@
                 clmDataStore.services.codeSchool.updateProfile = jasmine.createSpy('codeSchool.updateProfile');
                 profileObj.$loaded.and.returnValue($q.when(profile));
                 spfFirebase.set.and.returnValue(expectedReturn);
-                spfAuthData.user.and.returnValue($q.when({
-                  publicId: 'bob'
-                }));
 
-                clmDataStore.events.updateProgress(event).then(function(completedTasks) {
+                clmDataStore.events.updateProgress(event, 'bob').then(function(completedTasks) {
                   actualReturn = completedTasks;
                 });
 
@@ -907,11 +922,8 @@
                 profileObj.$loaded.and.returnValue($q.when({$id: profile.$id}));
                 spfFirebase.loadedObj.and.returnValue($q.when(profile));
                 spfFirebase.set.and.returnValue(expectedReturn);
-                spfAuthData.user.and.returnValue($q.when({
-                  publicId: 'bob'
-                }));
 
-                clmDataStore.events.updateProgress(event).then(function(completedTasks) {
+                clmDataStore.events.updateProgress(event, 'bob').then(function(completedTasks) {
                   actualReturn = completedTasks;
                 });
 
@@ -964,11 +976,8 @@
                 profileObj.$loaded.and.returnValue($q.when({$id: profile.$id}));
                 spfFirebase.loadedObj.and.returnValue($q.when(profile));
                 spfFirebase.set.and.returnValue(expectedReturn);
-                spfAuthData.user.and.returnValue($q.when({
-                  publicId: 'bob'
-                }));
 
-                clmDataStore.events.updateProgress(event).then(function(completedTasks) {
+                clmDataStore.events.updateProgress(event, 'bob').then(function(completedTasks) {
                   actualReturn = completedTasks;
                 });
 

--- a/src/classmentors/components/events/events.js
+++ b/src/classmentors/components/events/events.js
@@ -303,6 +303,7 @@
   controller('ViewEventCtrl', [
     'initialData',
     '$q',
+    '$log',
     '$document',
     '$mdDialog',
     'spfAlert',
@@ -311,7 +312,7 @@
     'clmDataStore',
     'clmServicesUrl',
     function ViewEventCtrl(
-      initialData, $q, $document, $mdDialog, spfAlert, urlFor, spfNavBarService, clmDataStore, clmServicesUrl
+      initialData, $q, $log, $document, $mdDialog, spfAlert, urlFor, spfNavBarService, clmDataStore, clmServicesUrl
     ) {
       var self = this;
       var linkers;
@@ -405,7 +406,12 @@
       }
 
       this.update = function() {
-        return clmDataStore.events.updateProgress(self.event);
+        return clmDataStore.events.updateProgress(self.event, self.currentUser.publicId).then(function() {
+          spfAlert.success('User progress updated');
+        }).catch(function(err) {
+          $log.error(err);
+          spfAlert.error('Failed to update progress');
+        });
       };
 
       this.updateAll = function() {

--- a/src/classmentors/components/events/events.spec.js
+++ b/src/classmentors/components/events/events.spec.js
@@ -16,10 +16,10 @@
     }));
 
     describe('ViewEventCtrl', function() {
-      var inject;
+      var deps;
 
       beforeEach(function() {
-        inject = {
+        deps = {
           initialData: {
             currentUser: {},
             event: {},
@@ -38,49 +38,49 @@
       it('should set currentUser, event, and participant properties', function() {
         var ctrl;
 
-        ctrl = $controller('ViewEventCtrl', inject);
+        ctrl = $controller('ViewEventCtrl', deps);
 
-        expect(ctrl.currentUser).toBe(inject.initialData.currentUser);
-        expect(ctrl.event).toBe(inject.initialData.event);
-        expect(ctrl.participants).toBe(inject.initialData.participants);
+        expect(ctrl.currentUser).toBe(deps.initialData.currentUser);
+        expect(ctrl.event).toBe(deps.initialData.event);
+        expect(ctrl.participants).toBe(deps.initialData.participants);
       });
 
       it('should set a menu title to event title', function() {
-        inject.initialData.event = {
+        deps.initialData.event = {
           title: 'some title'
         };
 
-        $controller('ViewEventCtrl', inject);
+        $controller('ViewEventCtrl', deps);
 
-        expect(inject.spfNavBarService.update).toHaveBeenCalledWith(
+        expect(deps.spfNavBarService.update).toHaveBeenCalledWith(
           'some title', jasmine.any(Object), jasmine.any(Array)
         );
       });
 
       it('should set a menu parent path to event list', function() {
-        inject.initialData.event = {
+        deps.initialData.event = {
           title: 'some title'
         };
 
-        $controller('ViewEventCtrl', inject);
+        $controller('ViewEventCtrl', deps);
 
-        expect(inject.spfNavBarService.update.calls.argsFor(0)[1]).toEqual(
+        expect(deps.spfNavBarService.update.calls.argsFor(0)[1]).toEqual(
           {title: 'Events', url: '#/events'}
         );
       });
 
       it('should not set any menu options if the user logged off', function() {
-        inject.initialData.event = {
+        deps.initialData.event = {
           title: 'some title'
         };
 
-        $controller('ViewEventCtrl', inject);
+        $controller('ViewEventCtrl', deps);
 
-        expect(inject.spfNavBarService.update.calls.argsFor(0)[2]).toEqual([]);
+        expect(deps.spfNavBarService.update.calls.argsFor(0)[2]).toEqual([]);
       });
 
       it('should set a join menu option if the user logged in', function() {
-        inject.initialData = {
+        deps.initialData = {
           event: {
             title: 'some title',
             owner: {}
@@ -93,17 +93,17 @@
           }
         };
 
-        inject.initialData.participants.$indexFor.and.returnValue(-1);
+        deps.initialData.participants.$indexFor.and.returnValue(-1);
 
-        $controller('ViewEventCtrl', inject);
+        $controller('ViewEventCtrl', deps);
 
-        expect(inject.spfNavBarService.update.calls.argsFor(0)[2]).toEqual(
+        expect(deps.spfNavBarService.update.calls.argsFor(0)[2]).toEqual(
           [{title: 'Join', onClick: jasmine.any(Function), icon: 'add-circle-outline'}]
         );
       });
 
       it('should set a leave menu option if the user logged in and a participant', function() {
-        inject.initialData = {
+        deps.initialData = {
           event: {
             title: 'some title',
             owner: {}
@@ -117,17 +117,17 @@
           }
         };
 
-        inject.initialData.participants.$indexFor.and.returnValue(0);
+        deps.initialData.participants.$indexFor.and.returnValue(0);
 
-        $controller('ViewEventCtrl', inject);
+        $controller('ViewEventCtrl', deps);
 
-        expect(inject.spfNavBarService.update.calls.argsFor(0)[2]).toEqual(
+        expect(deps.spfNavBarService.update.calls.argsFor(0)[2]).toEqual(
           [{title: 'Leave', onClick: jasmine.any(Function), icon: 'highlight-remove'}]
         );
       });
 
       it('should set an edit menu option if the user is the owner', function() {
-        inject.initialData = {
+        deps.initialData = {
           event: {
             $id: 'evenId',
             title: 'some title',
@@ -144,12 +144,12 @@
           }
         };
 
-        inject.initialData.participants.$indexFor.and.returnValue(0);
+        deps.initialData.participants.$indexFor.and.returnValue(0);
 
-        $controller('ViewEventCtrl', inject);
+        $controller('ViewEventCtrl', deps);
 
         expect(
-          inject.spfNavBarService.update.calls.argsFor(0)[2]
+          deps.spfNavBarService.update.calls.argsFor(0)[2]
         ).toEqual([
           jasmine.any(Object),
           {title: 'Edit', url: '#/events/evenId/edit', icon: 'create'},
@@ -158,7 +158,7 @@
       });
 
       it('should set an update menu option if the user is the owner', function() {
-        inject.initialData = {
+        deps.initialData = {
           event: {
             $id: 'evenId',
             title: 'some title',
@@ -175,12 +175,12 @@
           }
         };
 
-        inject.initialData.participants.$indexFor.and.returnValue(0);
+        deps.initialData.participants.$indexFor.and.returnValue(0);
 
-        $controller('ViewEventCtrl', inject);
+        $controller('ViewEventCtrl', deps);
 
         expect(
-          inject.spfNavBarService.update.calls.argsFor(0)[2]
+          deps.spfNavBarService.update.calls.argsFor(0)[2]
         ).toEqual([
           jasmine.any(Object),
           jasmine.any(Object),
@@ -191,13 +191,13 @@
       describe('completed', function() {
 
         it('should return 100 if there is no participants', function() {
-          var ctrl = $controller('ViewEventCtrl', inject);
+          var ctrl = $controller('ViewEventCtrl', deps);
 
           expect(ctrl.completed('12345')).toBe(100);
         });
 
         it('should return percentage of participants having completed the task', function() {
-          var ctrl = $controller('ViewEventCtrl', inject);
+          var ctrl = $controller('ViewEventCtrl', deps);
 
           ctrl.participants = {
             $id: 'eventId',
@@ -218,7 +218,7 @@
       describe('startLink', function() {
 
         it('should return a link to a singpath problem', function() {
-          var ctrl = $controller('ViewEventCtrl', inject);
+          var ctrl = $controller('ViewEventCtrl', deps);
           var task = {
             serviceId: 'singPath',
             singPathProblem: {
@@ -234,7 +234,7 @@
         });
 
         it('should return a link to a code school course', function() {
-          var ctrl = $controller('ViewEventCtrl', inject);
+          var ctrl = $controller('ViewEventCtrl', deps);
           var task = {
             serviceId: 'codeSchool',
             badge: {
@@ -248,7 +248,7 @@
         });
 
         it('should return a link to a code combat level', function() {
-          var ctrl = $controller('ViewEventCtrl', inject);
+          var ctrl = $controller('ViewEventCtrl', deps);
           var task = {
             serviceId: 'codeCombat',
             badge: {
@@ -265,20 +265,43 @@
 
       describe('update', function() {
 
-        it('should update the current user task completeness', function() {
-          var ctrl = $controller('ViewEventCtrl', inject);
+        it('should update the current user task completeness', inject(function($q) {
+          var ctrl = $controller('ViewEventCtrl', deps);
 
+          deps.clmDataStore.events.updateProgress.and.returnValue($q.when());
+
+          ctrl.currentUser = {publicId: 'bob'};
           ctrl.update();
 
-          expect(inject.clmDataStore.events.updateProgress).toHaveBeenCalledWith(inject.initialData.event);
-        });
+          expect(deps.clmDataStore.events.updateProgress).toHaveBeenCalledWith(deps.initialData.event, 'bob');
+        }));
+
+        it('should show success message on success', inject(function($q, $rootScope) {
+          var ctrl = $controller('ViewEventCtrl', deps);
+
+          deps.clmDataStore.events.updateProgress.and.returnValue($q.when());
+          ctrl.update();
+          $rootScope.$apply();
+
+          expect(deps.spfAlert.success).toHaveBeenCalled();
+        }));
+
+        it('should show error message on failure', inject(function($q, $rootScope) {
+          var ctrl = $controller('ViewEventCtrl', deps);
+
+          deps.clmDataStore.events.updateProgress.and.returnValue($q.reject(new Error()));
+          ctrl.update();
+          $rootScope.$apply();
+
+          expect(deps.spfAlert.error).toHaveBeenCalled();
+        }));
 
       });
 
       describe('updateAll', function() {
 
-        it('should update the current user task completeness', function() {
-          var ctrl = $controller('ViewEventCtrl', inject);
+        it('should update the all user task completeness', function() {
+          var ctrl = $controller('ViewEventCtrl', deps);
 
           ctrl.participants = {
             0: {$id: 'somePublicId'},
@@ -287,16 +310,16 @@
 
           ctrl.updateAll();
 
-          expect(inject.clmDataStore.events.updateProgress.calls.count()).toBe(2);
+          expect(deps.clmDataStore.events.updateProgress.calls.count()).toBe(2);
           expect(
-            inject.clmDataStore.events.updateProgress
+            deps.clmDataStore.events.updateProgress
           ).toHaveBeenCalledWith(
-            inject.initialData.event, 'somePublicId'
+            deps.initialData.event, 'somePublicId'
           );
           expect(
-            inject.clmDataStore.events.updateProgress
+            deps.clmDataStore.events.updateProgress
           ).toHaveBeenCalledWith(
-            inject.initialData.event, 'someOtherPublicId'
+            deps.initialData.event, 'someOtherPublicId'
           );
         });
 


### PR DESCRIPTION
The public id of the progress id became a required argument and test failed to catch error when it wasn’t provided.

I also added a success and error message when the update succeed or fails